### PR TITLE
Added explicit utf-8 encoding to two steps where html is written

### DIFF
--- a/src/unomd/main/run_html_export.py
+++ b/src/unomd/main/run_html_export.py
@@ -580,7 +580,7 @@ def save_molecule_viewer_html(config):
 </html>
 """
 
-        with open(config.get("path_molviewer_html"), "w") as f:
+        with open(config.get("path_molviewer_html"), "w", encoding='utf-8') as f:
             f.write(custom_html)
 
         logger.info(f"Location: {config.get('path_molviewer_html')}")
@@ -632,7 +632,7 @@ def save_rmsd_rmsf_html(config):
         
         # Save summary table
         summary_path = html_plot_path.replace('.html', '_summary.html')
-        with open(summary_path, 'w') as f:
+        with open(summary_path, 'w', encoding='utf-8') as f:
             f.write(summary_html)
         logger.info(f"Analysis summary table saved to: {summary_path}")
         


### PR DESCRIPTION
The utf-8 encoding is required on line 635 because that HTML file has the angstrom symbol, which can't be encoded in ASCII. The change on line 583 was not strictly necessary in my tests, since that HTML file lacks any non-ASCII characters, but for consistency's sake I thought we should have both writes be in utf-8, especially if that other HTML file is ever changed in the future.